### PR TITLE
Use raw JSON for data payloads

### DIFF
--- a/peer/message.go
+++ b/peer/message.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+type RespondFunc func(data interface{})
 type AcceptFunc func(data json.RawMessage)
 type RejectFunc func(errorCode int, errorReason string)
 

--- a/peer/message.go
+++ b/peer/message.go
@@ -8,6 +8,13 @@ import (
 type AcceptFunc func(data map[string]interface{})
 type RejectFunc func(errorCode int, errorReason string)
 
+type PeerMsg struct {
+	Request      bool `json:"request"`
+	Response     bool `json:"response"`
+	Ok           bool `json:"ok"`
+	Notification bool `json:"notification"`
+}
+
 /*
 * Request
 {

--- a/peer/message.go
+++ b/peer/message.go
@@ -1,11 +1,12 @@
 package peer
 
 import (
+	"encoding/json"
 	"math/rand"
 	"time"
 )
 
-type AcceptFunc func(data map[string]interface{})
+type AcceptFunc func(data json.RawMessage)
 type RejectFunc func(errorCode int, errorReason string)
 
 type PeerMsg struct {
@@ -29,10 +30,10 @@ type PeerMsg struct {
 }
 */
 type Request struct {
-	Request bool                   `json:"request"`
-	Id      int                    `json:"id"`
-	Method  string                 `json:"method"`
-	Data    map[string]interface{} `json:"data"`
+	Request bool            `json:"request"`
+	Id      int             `json:"id"`
+	Method  string          `json:"method"`
+	Data    json.RawMessage `json:"data"`
 }
 
 /*
@@ -48,10 +49,10 @@ type Request struct {
 }
 */
 type Response struct {
-	Response bool                   `json:"response"`
-	Id       int                    `json:"id"`
-	Ok       bool                   `json:"ok"`
-	Data     map[string]interface{} `json:"data"`
+	Response bool            `json:"response"`
+	Id       int             `json:"id"`
+	Ok       bool            `json:"ok"`
+	Data     json.RawMessage `json:"data"`
 }
 
 /*
@@ -84,9 +85,9 @@ type ResponseError struct {
 }
 */
 type Notification struct {
-	Notification bool                   `json:"notification"`
-	Method       string                 `json:"method"`
-	Data         map[string]interface{} `json:"data"`
+	Notification bool            `json:"notification"`
+	Method       string          `json:"method"`
+	Data         json.RawMessage `json:"data"`
 }
 
 func RandInt(min, max int) int {

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -54,7 +54,7 @@ func (peer *Peer) Request(method string, data interface{}, success AcceptFunc, r
 	id := GenerateRandomNumber()
 	dataStr, err := json.Marshal(data)
 	if err != nil {
-		logger.Errorf("Marshal %v", err)
+		logger.Errorf("Marshal data %v", err)
 		return
 	}
 	request := &Request{
@@ -86,7 +86,7 @@ func (peer *Peer) Request(method string, data interface{}, success AcceptFunc, r
 func (peer *Peer) Notify(method string, data interface{}) {
 	dataStr, err := json.Marshal(data)
 	if err != nil {
-		logger.Errorf("Marshal %v", err)
+		logger.Errorf("Marshal data %v", err)
 		return
 	}
 	notification := &Notification{
@@ -106,32 +106,37 @@ func (peer *Peer) Notify(method string, data interface{}) {
 func (peer *Peer) handleMessage(message []byte) {
 	var msg PeerMsg
 	if err := json.Unmarshal(message, &msg); err != nil {
-		panic(err)
+		logger.Errorf("Marshal %v", err)
+		return
 	}
 	if msg.Request {
 		var data Request
 		if err := json.Unmarshal(message, &data); err != nil {
-			panic(err)
+			logger.Errorf("Request Marshal %v", err)
+			return
 		}
 		peer.handleRequest(data)
 	} else if msg.Response {
 		if msg.Ok {
 			var data Response
 			if err := json.Unmarshal(message, &data); err != nil {
-				panic(err)
+				logger.Errorf("Response Marshal %v", err)
+				return
 			}
 			peer.handleResponse(data)
 		} else {
 			var data ResponseError
 			if err := json.Unmarshal(message, &data); err != nil {
-				panic(err)
+				logger.Errorf("ResponseError Marshal %v", err)
+				return
 			}
 			peer.handleResponseError(data)
 		}
 	} else if msg.Notification {
 		var data Notification
 		if err := json.Unmarshal(message, &data); err != nil {
-			panic(err)
+			logger.Errorf("Notification Marshal %v", err)
+			return
 		}
 		peer.handleNotification(data)
 	}


### PR DESCRIPTION
Replace usage of `map[string]interface{}` in peer with go `json.RawMessage` type. This allows us to keep the data opaque and let the client handle it using normal json decoding.
The benefit here is both parties can share a strong JSON contract instead of first checking, then casting fields from `interface{}` they hope are there.
https://golang.org/pkg/encoding/json/#RawMessage

Additionally parse messages into their appropriate type before handling. This made some of the request handing easier to read/code as we can naturally call `request.Method` and `response.Id` now without any casting.

For an example of the work needed to integrate these changes into Ion, take a look at this PR which uses the protoo client to join an Ion room and publish a stream.
https://github.com/jbrady42/ion-vid/pull/1
